### PR TITLE
Added namespace to build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'com.muxable.flutter.thermal'
     compileSdkVersion 30
 
     sourceSets {


### PR DESCRIPTION
Added missing namespace property to be compliant with AGP 8.0.0