### PR TITLE
use JVM Toolchain to use JDK 17 without conflicting with apps/plugins that use JDK 8 (1.8)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,6 +28,10 @@ android {
     namespace 'com.muxable.flutter.thermal'
     compileSdkVersion 34
 
+    kotlin {
+        jvmToolchain(17)
+     }
+
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }


### PR DESCRIPTION
One last thing for AGP 8 support. Thank you!