### PR TITLE
Added support for android <=9

### DIFF
--- a/android/src/main/kotlin/com/muxable/flutter/thermal/ThermalPlugin.kt
+++ b/android/src/main/kotlin/com/muxable/flutter/thermal/ThermalPlugin.kt
@@ -13,57 +13,66 @@ import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodChannel
 
-@RequiresApi(Build.VERSION_CODES.Q)
 class ThermalPlugin : FlutterPlugin {
     private lateinit var stateEventChannel: EventChannel
     private lateinit var methodChannel: MethodChannel
     private lateinit var batteryTemperatureEventChannel: EventChannel
-    private lateinit var powerManager: PowerManager
-
+    
     override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-        powerManager =
-            flutterPluginBinding.applicationContext.getSystemService(Context.POWER_SERVICE)
-                    as PowerManager
-        stateEventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "thermal/events")
-        stateEventChannel.setStreamHandler(object : EventChannel.StreamHandler,
-            PowerManager.OnThermalStatusChangedListener {
+        // Set up battery temperature event channel (works on all Android versions)
+        batteryTemperatureEventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "thermal/battery_temp/events")
+        batteryTemperatureEventChannel.setStreamHandler(object : EventChannel.StreamHandler, BroadcastReceiver() {
             private lateinit var sink: EventChannel.EventSink
-
-            override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
-                sink = events
-                powerManager.addThermalStatusListener(this)
-            }
-
-            override fun onCancel(arguments: Any?) {
-                powerManager.removeThermalStatusListener(this)
-            }
-
-            override fun onThermalStatusChanged(status: Int) {
-                sink.success(status)
-            }
-        })
-        batteryTemperatureEventChannel =
-            EventChannel(flutterPluginBinding.binaryMessenger, "thermal/battery_temp/events")
-        batteryTemperatureEventChannel.setStreamHandler(object : EventChannel.StreamHandler,
-            BroadcastReceiver() {
-            private lateinit var sink: EventChannel.EventSink
-
+            
             override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
                 sink = events
                 flutterPluginBinding.applicationContext.registerReceiver(
-                    this,
-                    IntentFilter(Intent.ACTION_BATTERY_CHANGED)
+                    this, IntentFilter(Intent.ACTION_BATTERY_CHANGED)
                 )
             }
-
+            
             override fun onCancel(arguments: Any?) {
                 flutterPluginBinding.applicationContext.unregisterReceiver(this)
             }
-
+            
             override fun onReceive(context: Context?, intent: Intent) {
                 sink.success(intent.getIntExtra(BatteryManager.EXTRA_TEMPERATURE, 0).toDouble() / 10)
             }
         })
+        
+        // Set up thermal status channels only for Android 10+ (API 29+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            setupThermalStatusHandlers(flutterPluginBinding)
+        } else {
+            // For older Android versions, set up dummy handlers that report unsupported
+            setupLegacyThermalStatusHandlers(flutterPluginBinding)
+        }
+    }
+    
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun setupThermalStatusHandlers(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        val powerManager = flutterPluginBinding.applicationContext.getSystemService(Context.POWER_SERVICE) as PowerManager
+        
+        // Thermal status event channel
+        stateEventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "thermal/events")
+        stateEventChannel.setStreamHandler(object : EventChannel.StreamHandler, PowerManager.OnThermalStatusChangedListener {
+            private lateinit var sink: EventChannel.EventSink
+            
+            override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+                sink = events
+                powerManager.addThermalStatusListener(this)
+            }
+            
+            override fun onCancel(arguments: Any?) {
+                powerManager.removeThermalStatusListener(this)
+            }
+            
+            override fun onThermalStatusChanged(status: Int) {
+                sink.success(status)
+            }
+        })
+        
+        // Method channel with thermal status methods
         methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "thermal")
         methodChannel.setMethodCallHandler { call, result ->
             when (call.method) {
@@ -72,10 +81,37 @@ class ThermalPlugin : FlutterPlugin {
             }
         }
     }
-
+    
+    private fun setupLegacyThermalStatusHandlers(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+        // Provide dummy implementation for thermal status event channel
+        stateEventChannel = EventChannel(flutterPluginBinding.binaryMessenger, "thermal/events")
+        stateEventChannel.setStreamHandler(object : EventChannel.StreamHandler {
+            override fun onListen(arguments: Any?, events: EventChannel.EventSink) {
+                // Send an initial THERMAL_STATUS_NONE (0) status for Android 9 and below
+                events.success(PowerManager.THERMAL_STATUS_NONE)
+            }
+            
+            override fun onCancel(arguments: Any?) {
+                // Nothing to clean up
+            }
+        })
+        
+        // Method channel with appropriate responses for unsupported devices
+        methodChannel = MethodChannel(flutterPluginBinding.binaryMessenger, "thermal")
+        methodChannel.setMethodCallHandler { call, result ->
+            when (call.method) {
+                "getThermalStatus" -> result.success(PowerManager.THERMAL_STATUS_NONE) // Always return THERMAL_STATUS_NONE for unsupported devices
+                else -> result.notImplemented()
+            }
+        }
+    }
+    
     override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
         stateEventChannel.setStreamHandler(null)
         batteryTemperatureEventChannel.setStreamHandler(null)
-        methodChannel.setMethodCallHandler(null)
+        
+        if (::methodChannel.isInitialized) {
+            methodChannel.setMethodCallHandler(null)
+        }
     }
 }


### PR DESCRIPTION
Added a dummy implementation for thermal status events on devices running Android 9 (API 28) and below. This method ensures that unsupported devices receive appropriate responses. Until now, calling plugin methods on Android <9 resulted in an exception.