### PR TITLE
fix(ios): dispatch thermal EventChannel callbacks on main queue

### DIFF
--- a/ios/thermal/Sources/thermal/SwiftThermalPlugin.swift
+++ b/ios/thermal/Sources/thermal/SwiftThermalPlugin.swift
@@ -16,6 +16,10 @@ public class SwiftThermalPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   }
 
   public func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    NotificationCenter.default.removeObserver(
+      self,
+      name: ProcessInfo.thermalStateDidChangeNotification,
+      object: nil)
     self.sink = nil
     return nil
   }
@@ -45,8 +49,11 @@ public class SwiftThermalPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   }
 
   @objc public func onThermalStateChanged(_ notification: Notification) {
-    if let events = self.sink {
-      events(SwiftThermalPlugin.toChannelValue(state: ProcessInfo.processInfo.thermalState))
+    guard let events = self.sink else { return }
+    let value = SwiftThermalPlugin.toChannelValue(state: ProcessInfo.processInfo.thermalState)
+    DispatchQueue.main.async { [weak self] in
+      guard self?.sink != nil else { return }
+      events(value)
     }
   }
 


### PR DESCRIPTION
## Summary

`ProcessInfo.thermalStateDidChangeNotification` can be delivered on a background dispatch queue. The current implementation invokes `FlutterEventSink` directly from `onThermalStateChanged`, which must run on the main thread. This causes `NSInternalInconsistencyException` in the Flutter engine when the device thermal state changes (e.g. under memory pressure while backgrounding).

This change:
- Dispatches EventChannel callbacks with `DispatchQueue.main.async`
- Guards against a nil sink after async hop with `[weak self]`
- Removes the `NotificationCenter` observer in `onCancel` when the stream is cancelled

## Reproduction

Observed in production application on Model: iPhone 13 Mini iOS Version:26.5.0 using thermal 1.2.1  when memory pressure + app background coincided with a thermal state notification.

Stack (abbreviated):
```
Fatal Exception: NSInternalInconsistencyException
SwiftThermalPlugin.onThermalStateChanged
NSProcessInfoNotifyThermalState
```

## Test plan

- [ ] Subscribe to `onThermalStatusChanged` on a physical iOS device
- [ ] Trigger thermal/memory pressure (or wait for natural OS notification)
- [ ] Confirm app does not crash and stream still receives updates
- [ ] Cancel stream subscription and confirm no further observer callbacks